### PR TITLE
Update 0_setup_env_ubuntu.sh

### DIFF
--- a/scripts/Linux/0_setup_env_ubuntu.sh
+++ b/scripts/Linux/0_setup_env_ubuntu.sh
@@ -7,4 +7,4 @@
 sudo apt-get update
 sudo apt-get install -y qt5-default qttools5-dev-tools qtdeclarative5-dev
 sudo apt-get install -y mesa-common-dev libglu1-mesa-dev
-sudo apt-get install -y libgmp-devlibcgal-dev libboost-all-dev patchelf cmake
+sudo apt-get install -y libgmp-dev libcgal-dev libboost-all-dev patchelf cmake


### PR DESCRIPTION
lack of space between 'libgmp-dev libcgal-dev' creating installation error. 

E: Unable to locate package libgmp-devlibcgal-dev